### PR TITLE
Upload ueberjar only for one plattform

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,14 @@ jobs:
         jdk: [ 22, 23 ]
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      # The reference JDK and OS are needed to define which job of the matrix build is
+      # allowed to upload the generated jar. Background: Uploading the same artifact multiple times
+      # will cause all builds except the first one to fail
+      REFERENCE_JDK_VERSION: '22'
+      REFERENCE_OS_NAME: 'macos-latest'
+
     steps:
       - name: Checkout Git Repository
         id: git-checkout
@@ -76,6 +84,9 @@ jobs:
 
       - name: Upload native binary
         uses: actions/upload-artifact@v4
+        # The native binary can be only uploaded once for a plattform, therefore we have decided
+        # to upload native binary only once for a given reference plattform
+        if: matrix.jdk == env.REFERENCE_JDK_VERSION
         with:
           name: ${{ steps.show-result.outputs.native_filename }}
           path: client/pure/target/${{ steps.show-result.outputs.native_filename }}
@@ -83,6 +94,9 @@ jobs:
 
       - name: Upload ueberjar
         uses: actions/upload-artifact@v4
+        # The Ueberjar can be only uploaded once, therefore we have decided to upload
+        # the artifact only once for a given reference plattform
+        if: matrix.jdk == env.REFERENCE_JDK_VERSION && matrix.os == env.REFERENCE_OS_NAME
         with:
           name: ${{ steps.show-result.outputs.ueberjar_filename }}
           path: client/pure/target/${{ steps.show-result.outputs.ueberjar_filename }}


### PR DESCRIPTION
The matrix build workflow for GitHub Actions was failing, because each run tried to upload the generated ueberjar. This change introduces a reference Java version and reference operating system and only the run for the combination of both is allowed to upload the ueberjar.