### PR TITLE
Add command to check for a Maven snapshot version

### DIFF
--- a/client/pure/src/main/java/fhg/tooling/semver/cli/ExitCodes.java
+++ b/client/pure/src/main/java/fhg/tooling/semver/cli/ExitCodes.java
@@ -4,6 +4,12 @@ public class ExitCodes {
     public static final int SUCCESS = 0;
 
     /**
+     * Generic error code value used to indicate that the execution of the command
+     * was not successful in the context of the executed subcommand.
+     */
+    public static final int NEGATIVE_EXECUTION_RESULT = 1;
+
+    /**
      * At least one of the given version identifiers is not a valid semantic version identifier.
      */
     public static final int INVALID_VERSION_IDENTIFIER = 10;

--- a/client/pure/src/main/java/fhg/tooling/semver/cli/SemVer.java
+++ b/client/pure/src/main/java/fhg/tooling/semver/cli/SemVer.java
@@ -15,6 +15,7 @@ import java.util.jar.Manifest;
         name = "semver",
         subcommands = {
                 ExtractSubcommand.class,
+                IsMavenSnapshotSubCommand.class,
                 NextMajorSubcommand.class, NextMinorSubcommand.class,
                 NextPatchSubcommand.class, StripSubcommand.class,
                 ValidateSubcommand.class},

--- a/client/pure/src/main/java/fhg/tooling/semver/cli/subcommands/IsMavenSnapshotSubCommand.java
+++ b/client/pure/src/main/java/fhg/tooling/semver/cli/subcommands/IsMavenSnapshotSubCommand.java
@@ -1,0 +1,58 @@
+package fhg.tooling.semver.cli.subcommands;
+
+import fhg.tooling.semver.cli.ExitCodes;
+import io.github.freiheitstools.semver.parser.api.SemVer;
+import picocli.CommandLine;
+import picocli.CommandLine.Mixin;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+/**
+ * Subcommand to check if a given semantic version represents a valid Maven snapshot version or not.
+ */
+@CommandLine.Command(name = "ismavensnapshot",
+        description = "Checks if the given semantic version is a Maven snapshot version or not",
+        exitCodeList = {
+                ExitCodes.SUCCESS + ": Given semantic version is a Maven snapshot version",
+                ExitCodes.NEGATIVE_EXECUTION_RESULT + ": Given semantic version isn't a Maven snapshot version",
+                ExitCodes.INVALID_VERSION_IDENTIFIER + ": Given version is not a valid semantic version"
+        }
+)
+public class IsMavenSnapshotSubCommand
+        implements Callable<Integer> {
+
+    /**
+     * Textual representation of the suffix {@code SNAPSHOT} used by
+     * Apache Maven to mark a given version as snapshot version.
+     */
+    private static final String SNAPSHOT = "SNAPSHOT";
+
+    @Mixin
+    private VersionParameter versionParameter = new VersionParameter();
+
+    @Override
+    public Integer call() {
+        SemVer given = SemVer.parser().parse(versionParameter.getVersion());
+
+        if (given.isInvalid()) {
+            System.err.println(versionParameter.getVersion() + " is not a valid semantic version");
+            return ExitCodes.INVALID_VERSION_IDENTIFIER;
+        }
+
+        Optional<String> preRelease = given.getPreRelease();
+
+        if (preRelease.isPresent()) {
+            String prerelease = preRelease.get();
+
+            if (Objects.equals(SNAPSHOT, prerelease)) {
+                System.err.println(versionParameter.getVersion() + " is a Maven snapshot version");
+                return ExitCodes.SUCCESS;
+            }
+        }
+
+        System.err.println(versionParameter.getVersion() + " is not a Maven snapshot version");
+        return ExitCodes.NEGATIVE_EXECUTION_RESULT;
+    }
+}

--- a/client/pure/src/test/java/fhg/tooling/semver/cli/SemVerTest.java
+++ b/client/pure/src/test/java/fhg/tooling/semver/cli/SemVerTest.java
@@ -40,12 +40,14 @@ class SemVerTest {
             expectedOutput.append("  -h, --help      Show this help message and exit.\n");
             expectedOutput.append("  -V, --version   Print version information and exit.\n");
             expectedOutput.append("Commands:\n");
-            expectedOutput.append("  extract    Allows to extract single parts from a version number\n");
-            expectedOutput.append("  nextmajor  Return the next major version for a given version\n");
-            expectedOutput.append("  nextminor  Return the next minor version for a given version\n");
-            expectedOutput.append("  nextpatch  Return the next patch version for a given version\n");
-            expectedOutput.append("  strip      Returns the version without suffix and build number\n");
-            expectedOutput.append("  validate   Validates a given version\n");
+            expectedOutput.append("  extract          Allows to extract single parts from a version number\n");
+            expectedOutput.append("  ismavensnapshot  Checks if the given semantic version is a Maven snapshot\n");
+            expectedOutput.append("                     version or not\n");
+            expectedOutput.append("  nextmajor        Return the next major version for a given version\n");
+            expectedOutput.append("  nextminor        Return the next minor version for a given version\n");
+            expectedOutput.append("  nextpatch        Return the next patch version for a given version\n");
+            expectedOutput.append("  strip            Returns the version without suffix and build number\n");
+            expectedOutput.append("  validate         Validates a given version\n");
 
             assertThat(outputStreamCaptor.toString()).isEqualTo(expectedOutput.toString());
             assertThat(exitCode).isEqualTo(0);

--- a/client/pure/src/test/java/fhg/tooling/semver/cli/subcommands/IsMavenSnapshotSubCommandTest.java
+++ b/client/pure/src/test/java/fhg/tooling/semver/cli/subcommands/IsMavenSnapshotSubCommandTest.java
@@ -1,0 +1,122 @@
+package fhg.tooling.semver.cli.subcommands;
+
+import fhg.tooling.semver.cli.ExitCodes;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IsMavenSnapshotSubCommandTest {
+    @Nested
+    class CommandlineArguments {
+        @Test
+        void positionalParameterForVersionStringIsMandatory() {
+            IsMavenSnapshotSubCommand command = new IsMavenSnapshotSubCommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            Assertions.assertThatThrownBy(cmdline::parseArgs)
+                      .isExactlyInstanceOf(CommandLine.MissingParameterException.class)
+                      .extracting(ex -> ((CommandLine.MissingParameterException) ex).getMissing())
+                      .asInstanceOf(InstanceOfAssertFactories.list(CommandLine.Model.ArgSpec.class))
+                      .hasSize(1)
+                      .first()
+                      .extracting(CommandLine.Model.ArgSpec::paramLabel).asString()
+                      .isEqualTo("version");
+        }
+
+        @Test
+        void positionalParameterForVersionStringIsMatched() {
+            IsMavenSnapshotSubCommand command = new IsMavenSnapshotSubCommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            CommandLine.ParseResult parseResult = cmdline.parseArgs("4.5.6-SNAPSHOT");
+
+            assertThat(parseResult.hasMatchedPositional(0)).isTrue();
+            assertThat(parseResult.matchedPositional(0).<String>getValue()).isEqualTo("4.5.6-SNAPSHOT");
+        }
+    }
+
+    @Nested
+    class Functional {
+        @Test
+        void realSnapshotVersionIsRecognizedAsSnapshotVersion() {
+            PrintStream stdoutStream = System.out;
+            PrintStream stderrStream = System.err;
+            ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+            ByteArrayOutputStream errorStreamCaptor = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(outputStreamCaptor));
+            System.setErr(new PrintStream(errorStreamCaptor));
+            int exitCode;
+
+            try {
+                IsMavenSnapshotSubCommand command = new IsMavenSnapshotSubCommand();
+                CommandLine cmdline = new CommandLine(command);
+
+                exitCode = cmdline.execute("4.6.0-SNAPSHOT");
+            } finally {
+                System.setOut(stdoutStream);
+                System.setErr(stderrStream);
+            }
+
+            assertThat(outputStreamCaptor.toString()).isEmpty();
+            assertThat(errorStreamCaptor.toString()).isEqualToNormalizingNewlines("4.6.0-SNAPSHOT is a Maven snapshot version\n");
+            assertThat(exitCode).isEqualTo(ExitCodes.SUCCESS);
+        }
+
+        @Test
+        void nonSnapshotVersionIsNotRecognizedAsSnapshotVersion() {
+            PrintStream stdoutStream = System.out;
+            PrintStream stderrStream = System.err;
+            ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+            ByteArrayOutputStream errorStreamCaptor = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(outputStreamCaptor));
+            System.setErr(new PrintStream(errorStreamCaptor));
+            int exitCode;
+
+            try {
+                IsMavenSnapshotSubCommand command = new IsMavenSnapshotSubCommand();
+                CommandLine cmdline = new CommandLine(command);
+
+                exitCode = cmdline.execute("4.6.0-DELTA");
+            } finally {
+                System.setOut(stdoutStream);
+                System.setErr(stderrStream);
+            }
+
+            assertThat(outputStreamCaptor.toString()).isEmpty();
+            assertThat(errorStreamCaptor.toString()).isEqualToNormalizingNewlines("4.6.0-DELTA is not a Maven snapshot version\n");
+            assertThat(exitCode).isEqualTo(ExitCodes.NEGATIVE_EXECUTION_RESULT);
+        }
+
+        @Test
+        void anInvalidSemanticVersionIsRecognized() {
+            PrintStream stdoutStream = System.out;
+            PrintStream stderrStream = System.err;
+            ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+            ByteArrayOutputStream errorStreamCaptor = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(outputStreamCaptor));
+            System.setErr(new PrintStream(errorStreamCaptor));
+            int exitCode;
+
+            try {
+                IsMavenSnapshotSubCommand command = new IsMavenSnapshotSubCommand();
+                CommandLine cmdline = new CommandLine(command);
+
+                exitCode = cmdline.execute("a4.6.0");
+            } finally {
+                System.setOut(stdoutStream);
+                System.setErr(stderrStream);
+            }
+
+            assertThat(outputStreamCaptor.toString()).isEmpty();
+            assertThat(errorStreamCaptor.toString()).isEqualToNormalizingNewlines("a4.6.0 is not a valid semantic version\n");
+            assertThat(exitCode).isEqualTo(ExitCodes.INVALID_VERSION_IDENTIFIER);
+        }
+    }
+}


### PR DESCRIPTION
Added the commend ismavenshot to check if a given semantic version is a valid Maven snapshot version or not.