### PR TITLE
Added Java 24 to the matrix build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        jdk: [ 22, 23 ]
+        jdk: [ 22, 23, 24 ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The semver cli will now be also built with Java 24. This should help to ensure, that the current implementation can be also built with future versions of Java.