### PR TITLE
Allow each command to be called with help option

### DIFF
--- a/client/src/main/java/fhg/tooling/semver/cli/subcommands/BumpingSubcommand.java
+++ b/client/src/main/java/fhg/tooling/semver/cli/subcommands/BumpingSubcommand.java
@@ -10,6 +10,9 @@ import java.util.stream.Stream;
 import static picocli.CommandLine.*;
 
 abstract class BumpingSubcommand {
+    @Option(names = {"-h", "--help"}, usageHelp = true, description = "display this help message")
+    boolean usageHelpRequested;
+
     @Mixin
     private SuffixOptions suffixOptions = new SuffixOptions();
 

--- a/client/src/main/java/fhg/tooling/semver/cli/subcommands/ExtractSubcommand.java
+++ b/client/src/main/java/fhg/tooling/semver/cli/subcommands/ExtractSubcommand.java
@@ -21,6 +21,9 @@ public class ExtractSubcommand
 
     private VersionPrinter printer = new VersionPrinter();
 
+    @Option(names = {"-h", "--help"}, usageHelp = true, description = "display this help message")
+    boolean usageHelpRequested;
+
     @Mixin
     private OutputOptions outputOptions = new OutputOptions();
 

--- a/client/src/main/java/fhg/tooling/semver/cli/subcommands/IsMavenSnapshotSubCommand.java
+++ b/client/src/main/java/fhg/tooling/semver/cli/subcommands/IsMavenSnapshotSubCommand.java
@@ -9,10 +9,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
+import static picocli.CommandLine.*;
+
 /**
  * Subcommand to check if a given semantic version represents a valid Maven snapshot version or not.
  */
-@CommandLine.Command(name = "ismavensnapshot",
+@Command(name = "ismavensnapshot",
         description = "Checks if the given semantic version is a Maven snapshot version or not",
         exitCodeList = {
                 ExitCodes.SUCCESS + ": Given semantic version is a Maven snapshot version",
@@ -28,6 +30,9 @@ public class IsMavenSnapshotSubCommand
      * Apache Maven to mark a given version as snapshot version.
      */
     private static final String SNAPSHOT = "SNAPSHOT";
+
+    @Option(names = {"-h", "--help"}, usageHelp = true, description = "display this help message")
+    boolean usageHelpRequested;
 
     @Mixin
     private VersionParameter versionParameter = new VersionParameter();

--- a/client/src/main/java/fhg/tooling/semver/cli/subcommands/StripSubcommand.java
+++ b/client/src/main/java/fhg/tooling/semver/cli/subcommands/StripSubcommand.java
@@ -2,14 +2,20 @@ package fhg.tooling.semver.cli.subcommands;
 
 import fhg.tooling.semver.cli.ExitCodes;
 import io.github.freiheitstools.semver.parser.api.SemVer;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
 import java.util.concurrent.Callable;
 
+import static picocli.CommandLine.*;
+
 @Command(name = "strip",
         description = "Returns the version without suffix and build number")
 public class StripSubcommand implements Callable<Integer> {
+    @Option(names = {"-h", "--help"}, usageHelp = true, description = "display this help message")
+    boolean usageHelpRequested;
+
     @Mixin
     private VersionParameter versionParameter = new VersionParameter();
 

--- a/client/src/main/java/fhg/tooling/semver/cli/subcommands/ValidateSubcommand.java
+++ b/client/src/main/java/fhg/tooling/semver/cli/subcommands/ValidateSubcommand.java
@@ -2,10 +2,13 @@ package fhg.tooling.semver.cli.subcommands;
 
 import fhg.tooling.semver.cli.ExitCodes;
 import io.github.freiheitstools.semver.parser.api.SemVer;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 
 import java.util.concurrent.Callable;
+
+import static picocli.CommandLine.*;
 
 @Command(name = "validate",
          description = "Validates a given version")
@@ -13,6 +16,8 @@ public class ValidateSubcommand implements Callable<Integer> {
     @Mixin
     private VersionParameter versionParameter = new VersionParameter();
 
+    @Option(names = {"-h", "--help"}, usageHelp = true, description = "display this help message")
+    boolean usageHelpRequested;
 
     public Integer call() throws Exception {
         SemVer given = SemVer.parser().parse(versionParameter.getVersion());

--- a/client/src/test/java/fhg/tooling/semver/cli/subcommands/ExtractSubcommandTest.java
+++ b/client/src/test/java/fhg/tooling/semver/cli/subcommands/ExtractSubcommandTest.java
@@ -108,6 +108,19 @@ class ExtractSubcommandTest {
             assertThat(parseResult.matchedOptions()).hasSize(2);
             assertThat(parseResult.matchedOption("-n")).isNotNull();
         }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-h", "--help"})
+        void callWithHelpOptionIsPossible(String option) {
+            ExtractSubcommand command = new ExtractSubcommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            CommandLine.ParseResult parseResult = cmdline.parseArgs(option);
+
+            assertThat(parseResult.matchedOptions()).hasSize(1);
+            assertThat(parseResult.matchedOption(option).isOption()).isTrue();
+        }
+
     }
 
 

--- a/client/src/test/java/fhg/tooling/semver/cli/subcommands/IsMavenSnapshotSubCommandTest.java
+++ b/client/src/test/java/fhg/tooling/semver/cli/subcommands/IsMavenSnapshotSubCommandTest.java
@@ -5,6 +5,8 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 import java.io.ByteArrayOutputStream;
@@ -40,6 +42,19 @@ class IsMavenSnapshotSubCommandTest {
             assertThat(parseResult.hasMatchedPositional(0)).isTrue();
             assertThat(parseResult.matchedPositional(0).<String>getValue()).isEqualTo("4.5.6-SNAPSHOT");
         }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-h", "--help"})
+        void callWithHelpOptionIsPossible(String option) {
+            IsMavenSnapshotSubCommand command = new IsMavenSnapshotSubCommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            CommandLine.ParseResult parseResult = cmdline.parseArgs(option);
+
+            assertThat(parseResult.matchedOptions()).hasSize(1);
+            assertThat(parseResult.matchedOption(option).isOption()).isTrue();
+        }
+
     }
 
     @Nested

--- a/client/src/test/java/fhg/tooling/semver/cli/subcommands/NextMajorSubcommandTest.java
+++ b/client/src/test/java/fhg/tooling/semver/cli/subcommands/NextMajorSubcommandTest.java
@@ -2,6 +2,8 @@ package fhg.tooling.semver.cli.subcommands;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 import java.io.ByteArrayOutputStream;
@@ -36,6 +38,18 @@ class NextMajorSubcommandTest {
             assertThat(parseResult.matchedOptions()).hasSize(1);
             assertThat(parseResult.matchedOption("--suffix").isOption()).isTrue();
             assertThat(parseResult.matchedOption("--suffix").<String>getValue()).isEqualTo("DELTA");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-h", "--help"})
+        void callWithHelpOptionIsPossible(String option) {
+            NextMajorSubcommand command = new NextMajorSubcommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            CommandLine.ParseResult parseResult = cmdline.parseArgs(option);
+
+            assertThat(parseResult.matchedOptions()).hasSize(1);
+            assertThat(parseResult.matchedOption(option).isOption()).isTrue();
         }
     }
 

--- a/client/src/test/java/fhg/tooling/semver/cli/subcommands/NextMinorSubcommandTest.java
+++ b/client/src/test/java/fhg/tooling/semver/cli/subcommands/NextMinorSubcommandTest.java
@@ -2,6 +2,8 @@ package fhg.tooling.semver.cli.subcommands;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 import java.io.ByteArrayOutputStream;
@@ -37,6 +39,19 @@ class NextMinorSubcommandTest {
             assertThat(parseResult.matchedOption("--suffix").isOption()).isTrue();
             assertThat(parseResult.matchedOption("--suffix").<String>getValue()).isEqualTo("DELTA");
         }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-h", "--help"})
+        void callWithHelpOptionIsPossible(String option) {
+            NextMinorSubcommand command = new NextMinorSubcommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            CommandLine.ParseResult parseResult = cmdline.parseArgs(option);
+
+            assertThat(parseResult.matchedOptions()).hasSize(1);
+            assertThat(parseResult.matchedOption(option).isOption()).isTrue();
+        }
+
     }
 
     @Nested

--- a/client/src/test/java/fhg/tooling/semver/cli/subcommands/NextPatchSubcommandTest.java
+++ b/client/src/test/java/fhg/tooling/semver/cli/subcommands/NextPatchSubcommandTest.java
@@ -2,6 +2,8 @@ package fhg.tooling.semver.cli.subcommands;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 import java.io.ByteArrayOutputStream;
@@ -36,6 +38,18 @@ class NextPatchSubcommandTest {
             assertThat(parseResult.matchedOptions()).hasSize(1);
             assertThat(parseResult.matchedOption("--suffix").isOption()).isTrue();
             assertThat(parseResult.matchedOption("--suffix").<String>getValue()).isEqualTo("DELTA");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"-h", "--help"})
+        void callWithHelpOptionIsPossible(String option) {
+            NextPatchSubcommand command = new NextPatchSubcommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            CommandLine.ParseResult parseResult = cmdline.parseArgs(option);
+
+            assertThat(parseResult.matchedOptions()).hasSize(1);
+            assertThat(parseResult.matchedOption(option).isOption()).isTrue();
         }
     }
 

--- a/client/src/test/java/fhg/tooling/semver/cli/subcommands/StripSubcommandTest.java
+++ b/client/src/test/java/fhg/tooling/semver/cli/subcommands/StripSubcommandTest.java
@@ -2,6 +2,8 @@ package fhg.tooling.semver.cli.subcommands;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 import java.io.ByteArrayOutputStream;
@@ -112,4 +114,18 @@ class StripSubcommandTest {
         }
     }
 
+    @Nested
+    class CommandlineArguments {
+        @ParameterizedTest
+        @ValueSource(strings = {"-h", "--help"})
+        void callWithHelpOptionIsPossible(String option) {
+            StripSubcommand command = new StripSubcommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            CommandLine.ParseResult parseResult = cmdline.parseArgs(option);
+
+            assertThat(parseResult.matchedOptions()).hasSize(1);
+            assertThat(parseResult.matchedOption(option).isOption()).isTrue();
+        }
+    }
 }

--- a/client/src/test/java/fhg/tooling/semver/cli/subcommands/ValidateSubcommandTest.java
+++ b/client/src/test/java/fhg/tooling/semver/cli/subcommands/ValidateSubcommandTest.java
@@ -1,0 +1,33 @@
+package fhg.tooling.semver.cli.subcommands;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ValidateSubcommandTest {
+    @Nested
+    class CommandlineArguments {
+        @ParameterizedTest
+        @ValueSource(strings = {"-h", "--help"})
+        void callWithHelpOptionIsPossible(String option) {
+            ValidateSubcommand command = new ValidateSubcommand();
+            CommandLine cmdline = new CommandLine(command);
+
+            CommandLine.ParseResult parseResult = cmdline.parseArgs(option);
+
+            assertThat(parseResult.matchedOptions()).hasSize(1);
+            assertThat(parseResult.matchedOption(option).isOption()).isTrue();
+        }
+    }
+
+    @Nested
+    class Functional {
+    }
+}


### PR DESCRIPTION
Each subcommand can now be called with the option `--help`, so that the user user cann request the help message for each subcommand.