### PR TITLE
Fix typo in ExitCodes Javadoc comment

### DIFF
--- a/client/src/main/java/fhg/tooling/semver/cli/ExitCodes.java
+++ b/client/src/main/java/fhg/tooling/semver/cli/ExitCodes.java
@@ -15,7 +15,7 @@ public class ExitCodes {
     public static final int INVALID_VERSION_IDENTIFIER = 10;
 
     /**
-     * The executed command requires a non-existing segment in the valie semantic version identifier
+     * The executed command requires a non-existing segment in the valid semantic version identifier
      * which is not present.
      */
     public static final int MISSING_SEGMENT = 20;


### PR DESCRIPTION
Correct "valie" to "valid" in the `MISSING_SEGMENT` constant documentation.